### PR TITLE
fix(options): Check if the option exists in camelCase

### DIFF
--- a/src/Command/index.js
+++ b/src/Command/index.js
@@ -70,7 +70,7 @@ class Command {
       params[this.args[index].name] = value || null
     })
     _.each(commandOptions._events, (option, name) => {
-      options[name] = commandOptions[name] || null
+      options[name] = commandOptions[name] || commandOptions[_.camelCase(name)] || null
     })
     this.setup()
     co(function * () {

--- a/test/unit/command.spec.js
+++ b/test/unit/command.spec.js
@@ -221,4 +221,23 @@ describe('Command', function () {
     expect(commandData.args).deep.equal({name: 'UserModel'})
     expect(commandData.options).deep.equal({migration: true})
   })
+
+  it('should be able to have options with hyphen', function () {
+    const commandData = {}
+    class NewCommand extends Command {
+      get signature () {
+        return 'new {name} {--skip-install}'
+      }
+      * handle (args, options) {
+        commandData.args = args
+        commandData.options = options
+      }
+    }
+    class ControllerGenerator extends Command {}
+    new NewCommand().initialize()
+    const controller = new ControllerGenerator()
+    controller.run('new', ['awesome-project'], {'skip-install': true})
+    expect(commandData.args).deep.equal({name: 'awesome-project'})
+    expect(commandData.options).deep.equal({'skip-install': true})
+  })
 })


### PR DESCRIPTION
Hey !

The package `commander` automatically transform options into camelCase format. If some options are created in kebab-case `ace` will not be able to get it.

**Note**: Commit's messages are wrong, you should replace `snake-case` with `kebab-case`.