### PR TITLE
feat(colors): use kleur instead of chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,13 +40,13 @@
     }
   },
   "dependencies": {
-    "chalk": "^2.4.1",
     "cli-table": "^0.3.1",
     "commander": "^2.16.0",
     "debug": "^3.1.0",
     "enquirer": "^1.0.3",
     "fs-extra": "^6.0.1",
     "is-arrow-function": "^2.0.3",
+    "kleur": "^2.0.1",
     "lodash": "^4.17.10",
     "mustache": "^2.3.0",
     "prompt-checkbox": "^2.2.0",

--- a/src/Command/index.js
+++ b/src/Command/index.js
@@ -10,7 +10,7 @@
 */
 
 const _ = require('lodash')
-const chalk = require('chalk')
+const kleur = require('kleur')
 const fs = require('fs-extra')
 const mustache = require('mustache')
 const Table = require('cli-table')
@@ -43,7 +43,11 @@ const defaults = {
  */
 class Command {
   constructor () {
-    this.chalk = new chalk.constructor({ enabled: process.env.NO_ANSI === 'false' })
+    this.chalk = kleur
+
+    if (process.env.NO_ANSI === 'false') {
+      kleur.enabled = false
+    }
 
     /**
      * List of icons
@@ -390,9 +394,12 @@ class Command {
    * @return {String}
    */
   static outputHelp (colorize = process.env.NO_ANSI === 'false') {
-    const ctx = new chalk.constructor({ enabled: colorize })
     const stringifiedArgs = this._stringifyArgs()
     const maxWidth = this.biggestArg()
+
+    if (!colorize) {
+      kleur.enabled = false
+    }
 
     /**
      * Push new lines to the strings array
@@ -407,7 +414,7 @@ class Command {
      *
      * @type {String}
      */
-    strings.push(ctx.magenta.bold('Usage:'))
+    strings.push(kleur.magenta.bold('Usage:'))
     const args = stringifiedArgs.length ? ` ${stringifiedArgs}` : ''
     strings.push(`  ${this.commandName}${args} [options]`)
 
@@ -416,9 +423,9 @@ class Command {
      */
     if (this.args.length) {
       strings.push(WHITE_SPACE)
-      strings.push(ctx.magenta.bold('Arguments:'))
+      strings.push(kleur.magenta.bold('Arguments:'))
       _.each(this.args, (arg) => {
-        strings.push(`  ${ctx.blue(_.padEnd(arg.name, maxWidth))} ${arg.description}`)
+        strings.push(`  ${kleur.blue(_.padEnd(arg.name, maxWidth))} ${arg.description}`)
       })
     }
 
@@ -427,9 +434,9 @@ class Command {
      */
     if (this.options.length) {
       strings.push(WHITE_SPACE)
-      strings.push(ctx.magenta.bold('Options:'))
+      strings.push(kleur.magenta.bold('Options:'))
       _.each(this.options, (option) => {
-        strings.push(`  ${ctx.blue(_.padEnd(this._getArgOrOptionName(option), maxWidth))} ${option.description}`)
+        strings.push(`  ${kleur.blue(_.padEnd(this._getArgOrOptionName(option), maxWidth))} ${option.description}`)
       })
     }
 
@@ -438,10 +445,11 @@ class Command {
      */
     if (this.description) {
       strings.push(WHITE_SPACE)
-      strings.push(ctx.magenta.bold('About:'))
+      strings.push(kleur.magenta.bold('About:'))
       strings.push(`  ${this.description}`)
     }
 
+    kleur.enabled = true
     strings.push(WHITE_SPACE)
     return strings.join('\n')
   }

--- a/src/Kernel/index.js
+++ b/src/Kernel/index.js
@@ -10,7 +10,7 @@
 */
 
 const _ = require('lodash')
-const chalk = require('chalk')
+const kleur = require('kleur')
 const isArrowFunction = require('is-arrow-function')
 
 const Command = require('../Command')
@@ -341,15 +341,18 @@ class Kernel {
    */
   outputHelp (options, colorize = process.env.NO_ANSI === 'false') {
     const strings = []
-    const ctx = new chalk.constructor({ enabled: colorize })
     const commandsGroup = this._groupCommands()
     const groupNames = _.keys(commandsGroup).sort()
     const maxWidth = this._largestCommandLength(_.map(options, (option) => option.long)) + 2
 
+    if (!colorize) {
+      kleur.enabled = false
+    }
+
     /**
      * Usage lines
      */
-    strings.push(ctx.magenta.bold('Usage:'))
+    strings.push(kleur.magenta.bold('Usage:'))
     strings.push('  command [arguments] [options]')
 
     /**
@@ -357,9 +360,9 @@ class Kernel {
      */
     if (_.size(options)) {
       strings.push(WHITE_SPACE)
-      strings.push(ctx.magenta.bold('Global Options:'))
+      strings.push(kleur.magenta.bold('Global Options:'))
       _.each(options, (option) => {
-        strings.push(`  ${ctx.blue(_.padEnd(option.long, maxWidth))} ${option.description}`)
+        strings.push(`  ${kleur.blue(_.padEnd(option.long, maxWidth))} ${option.description}`)
       })
     }
 
@@ -368,12 +371,13 @@ class Kernel {
      */
     if (_.size(groupNames)) {
       strings.push(WHITE_SPACE)
-      strings.push(ctx.magenta.bold('Available Commands:'))
+      strings.push(kleur.magenta.bold('Available Commands:'))
       _.each(groupNames, (groupName) => {
-        this._pushGroups(groupName, commandsGroup[groupName], maxWidth, ctx, strings)
+        this._pushGroups(groupName, commandsGroup[groupName], maxWidth, kleur, strings)
       })
     }
 
+    kleur.enabled = true
     strings.push(WHITE_SPACE)
     return strings.join('\n')
   }


### PR DESCRIPTION
Hey! 👋 

This PR change how colours are handled in the CLI.
It removes `chalk` and use `kleur` instead without creating breaking change for the final user.

`kleur` is more performant and is also super lightweight.

In the next major version, we could rename `this.chalk` by `this.colo(u)rs`, it will let us swap again library without the final user noticing it.

I can also add in this PR `this.colo(u)r` and we can start deprecate `this.chalk`.