### PR TITLE
refactor: remove pad-right dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5672,14 +5672,6 @@
         }
       }
     },
-    "pad-right": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/pad-right/-/pad-right-0.2.2.tgz",
-      "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
-      "requires": {
-        "repeat-string": "^1.5.2"
-      }
-    },
     "param-case": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.3.tgz",
@@ -6203,7 +6195,8 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "replace-ext": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "fast-levenshtein": "^2.0.6",
     "fs-extra": "^8.1.0",
     "getopts": "^2.2.4",
-    "pad-right": "^0.2.2",
     "param-case": "^3.0.3",
     "pascal-case": "^3.1.1",
     "pluralize": "^8.0.0",

--- a/src/utils/help.ts
+++ b/src/utils/help.ts
@@ -7,7 +7,6 @@
 * file that was distributed with this source code.
 */
 
-import padRight from 'pad-right'
 import { green, bold, yellow, dim } from 'kleur'
 import { sortAndGroupCommands } from './sortAndGroupCommands'
 import { CommandArg, CommandFlag, SerializedCommandContract } from '../Contracts'
@@ -109,7 +108,7 @@ export function printHelp (commands: SerializedCommandContract[], flags: Command
     }
 
     groupCommands.forEach(({ commandName, description }) => {
-      console.log(`  ${green(padRight(commandName, maxWidth, ' '))}  ${dim(description)}`)
+      console.log(`  ${green(commandName.padEnd(maxWidth, ' '))}  ${dim(description)}`)
     })
   })
 
@@ -118,7 +117,7 @@ export function printHelp (commands: SerializedCommandContract[], flags: Command
     console.log(bold(yellow('Global Flags')))
 
     flagsList.forEach(({ displayName, displayType, description = '', width }) => {
-      const whiteSpace = padRight('', maxWidth - width, ' ')
+      const whiteSpace = ''.padEnd(maxWidth - width, ' ')
       console.log(`  ${green(displayName)} ${dim(displayType)} ${whiteSpace}  ${dim(description)}`)
     })
   }
@@ -149,7 +148,7 @@ export function printHelpFor (command: SerializedCommandContract): void {
     console.log(bold(yellow('Arguments')))
 
     args.forEach(({ displayName, description = '', width }) => {
-      const whiteSpace = padRight('', maxWidth - width, ' ')
+      const whiteSpace = ''.padEnd(maxWidth - width, ' ')
       console.log(`  ${green(displayName)} ${whiteSpace}   ${dim(description)}`)
     })
   }
@@ -159,7 +158,7 @@ export function printHelpFor (command: SerializedCommandContract): void {
     console.log(bold(yellow('Flags')))
 
     flags.forEach(({ displayName, displayType, description = '', width }) => {
-      const whiteSpace = padRight('', maxWidth - width, ' ')
+      const whiteSpace = ''.padEnd(maxWidth - width, ' ')
       console.log(`  ${green(displayName)} ${dim(displayType)} ${whiteSpace}  ${dim(description)}`)
     })
   }


### PR DESCRIPTION
String.prototype.padEnd can be used instead.
