### PR TITLE
refactor: replace smpltmpl dependency with internal function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -720,7 +720,8 @@
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "any-observable": {
       "version": "0.5.1",
@@ -831,6 +832,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
@@ -1210,6 +1212,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "requires": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -1221,12 +1224,14 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2439,7 +2444,8 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "execa": {
       "version": "0.7.0",
@@ -3033,6 +3039,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -3040,7 +3047,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
         }
       }
     },
@@ -3990,7 +3998,8 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -6532,6 +6541,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/smpltmpl/-/smpltmpl-1.0.2.tgz",
       "integrity": "sha512-Hq23NNgeZigOzIiX1dkb6W3gFn2/XQj43KhPxu65IMieG/gIwf/lQb1IudjYv0c/5LwJeS/mPayYzyo+8WJMxQ==",
+      "dev": true,
       "requires": {
         "babel-code-frame": "^6.26.0"
       }
@@ -6878,7 +6888,8 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "supports-hyperlinks": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "pascal-case": "^3.1.1",
     "pluralize": "^8.0.0",
     "slash": "^3.0.0",
-    "smpltmpl": "^1.0.2",
     "snake-case": "^3.0.3"
   },
   "nyc": {

--- a/src/Generator/File.ts
+++ b/src/Generator/File.ts
@@ -8,9 +8,9 @@
 */
 
 import { basename, join, isAbsolute, sep } from 'path'
-import { template, templateFromFile } from 'smpltmpl'
 import { StringTransformer } from './StringTransformer'
 import { GeneratorFileOptions, GeneratorFileContract } from '../Contracts'
+import { template, templateFromFile } from '../utils/template'
 
 /**
  * Exposes the API to construct the output file content, path

--- a/src/utils/template.ts
+++ b/src/utils/template.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'fs'
+
+export function template (tpl, data) {
+  return tpl.replace(/\$\{([a-zA-Z0-9_-]*)}/g, (_, p1: string) => {
+    if (!(p1 in data)) {
+      throw new Error(`Missing value for "${p1}"`)
+    }
+    return String(data[p1])
+  })
+}
+
+export function templateFromFile (file: string, data: object): string {
+  const contents = readFileSync(file, 'utf8')
+  return template(contents, data)
+}

--- a/test/fixtures/template1.txt
+++ b/test/fixtures/template1.txt
@@ -1,0 +1,1 @@
+Hello ${value1}, ${value2}

--- a/test/template.spec.ts
+++ b/test/template.spec.ts
@@ -1,0 +1,48 @@
+/*
+ * @adonisjs/ace
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+import test from 'japa'
+import { join } from 'path'
+import { template, templateFromFile } from '../src/utils/template'
+
+test.group('template', () => {
+  test('template: interpolate valid template', (assert) => {
+    const result = template('${test} ${other}', {
+      test: 123,
+      other: 'hello',
+    })
+    assert.strictEqual(result, '123 hello')
+  })
+
+  test('template: error if a value is missing', (assert) => {
+    assert.throws(
+      () => template('${param}', {}),
+      'Missing value for "param"'
+    )
+  })
+
+  test('templateFromFile: interpolate valid template', (assert) => {
+    const result = templateFromFile(join(__dirname, 'fixtures/template1.txt'), {
+      value1: 'World',
+      value2: 42,
+    })
+
+    assert.strictEqual(result, 'Hello World, 42')
+  })
+
+  test('templateFromFile: error if a value is missing', (assert) => {
+    assert.throws(() => templateFromFile(join(__dirname, 'fixtures/template1.txt'), {
+      value1: 'World',
+    }), 'Missing value for "value2"')
+  })
+
+  test('templateFromFile: error if file is missing', (assert) => {
+    assert.throws(() => templateFromFile(join(__dirname, 'fixtures/i-do-not-exist'), {}))
+  })
+})


### PR DESCRIPTION
smpltmpl depends on babel-code-frame, which, with its subdependencies
adds about 10 unnecessary packages to the tree in production.
Moreover, it interpolates the template by running it as code in a Node.js
vm, which is not that simple, for a "simple" library.
Replace it with a simple internal implementation.

