### PR TITLE
feat(Kernel): exit the process by default after execution

### DIFF
--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            August 17th 2020, 7:21:27 am
+                            August 17th 2020, 7:35:21 am
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            August 6th 2020, 5:39:46 pm
+                            August 17th 2020, 7:21:27 am
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/src/BaseCommand/index.ts
+++ b/src/BaseCommand/index.ts
@@ -61,6 +61,11 @@ export abstract class BaseCommand implements CommandContract {
 	public static booted: boolean
 
 	/**
+	 * Defines if the command should never end by itself.
+	 */
+	public static stayAlive: boolean
+
+	/**
 	 * Boots the command by defining required static properties
 	 */
 	public static boot() {
@@ -82,6 +87,10 @@ export abstract class BaseCommand implements CommandContract {
 
 		if (!this.hasOwnProperty('description')) {
 			Object.defineProperty(this, 'description', { value: '' })
+		}
+
+		if (!this.hasOwnProperty('stayAlive')) {
+			Object.defineProperty(this, 'stayAlive', { value: false })
 		}
 	}
 

--- a/src/BaseCommand/index.ts
+++ b/src/BaseCommand/index.ts
@@ -61,11 +61,6 @@ export abstract class BaseCommand implements CommandContract {
 	public static booted: boolean
 
 	/**
-	 * Defines if the command should never end by itself.
-	 */
-	public static stayAlive: boolean
-
-	/**
 	 * Boots the command by defining required static properties
 	 */
 	public static boot() {
@@ -87,10 +82,6 @@ export abstract class BaseCommand implements CommandContract {
 
 		if (!this.hasOwnProperty('description')) {
 			Object.defineProperty(this, 'description', { value: '' })
-		}
-
-		if (!this.hasOwnProperty('stayAlive')) {
-			Object.defineProperty(this, 'stayAlive', { value: false })
 		}
 	}
 

--- a/src/Contracts/index.ts
+++ b/src/Contracts/index.ts
@@ -82,12 +82,16 @@ export type SerializedCommand = {
  */
 export interface CommandConstructorContract extends SerializedCommand {
 	new (application: ApplicationContract, kernel: KernelContract, ...args: any[]): CommandContract
-
 	/**
 	 * A boolean to know if the command has been booted or not. We initialize some
 	 * static properties to the class during the boot process.
 	 */
 	booted: boolean
+
+	/**
+	 * Defines if the command should never end by itself.
+	 */
+	stayAlive: boolean
 
 	/**
 	 * Boot the command. You won't have to run this method by yourself. Ace will internally

--- a/src/Contracts/index.ts
+++ b/src/Contracts/index.ts
@@ -89,11 +89,6 @@ export interface CommandConstructorContract extends SerializedCommand {
 	booted: boolean
 
 	/**
-	 * Defines if the command should never end by itself.
-	 */
-	stayAlive: boolean
-
-	/**
 	 * Boot the command. You won't have to run this method by yourself. Ace will internally
 	 * boot the commands by itself.
 	 */

--- a/src/Kernel/index.ts
+++ b/src/Kernel/index.ts
@@ -321,7 +321,7 @@ export class Kernel implements KernelContract {
 		const response = await this.application.container.call(commandInstance, 'handle', [])
 		await this.hooks.excute('after', 'run', commandInstance)
 
-		if (!command.stayAlive) {
+		if (!command.settings.stayAlive) {
 			process.exit(0)
 		}
 

--- a/src/Kernel/index.ts
+++ b/src/Kernel/index.ts
@@ -321,6 +321,10 @@ export class Kernel implements KernelContract {
 		const response = await this.application.container.call(commandInstance, 'handle', [])
 		await this.hooks.excute('after', 'run', commandInstance)
 
+		if (!command.stayAlive) {
+			process.exit(0)
+		}
+
 		return response
 	}
 

--- a/test/kernel.spec.ts
+++ b/test/kernel.spec.ts
@@ -1429,7 +1429,11 @@ test.group('Kernel | exec', () => {
 
 		class Foo extends BaseCommand {
 			public static commandName = 'foo'
-			public static stayAlive = true
+			public static get settings() {
+				return {
+					stayAlive: true,
+				}
+			}
 
 			public async handle() {}
 		}

--- a/test/kernel.spec.ts
+++ b/test/kernel.spec.ts
@@ -22,6 +22,9 @@ import { BaseCommand } from '../src/BaseCommand'
 
 const fs = new Filesystem(join(__dirname, '__app'))
 
+// @ts-expect-error
+process.exit = function () {}
+
 test.group('Kernel | register', () => {
 	test('raise error when required argument comes after optional argument', (assert) => {
 		class Greet extends BaseCommand {
@@ -1392,5 +1395,54 @@ test.group('Kernel | exec', () => {
 		})
 
 		await kernel.exec('foo', [])
+	})
+	test('exit the process by default', async (assert) => {
+		assert.plan(1)
+
+		// @ts-expect-error
+		process.exit = (code) => {
+			assert.equal(code, 0)
+		}
+
+		class Foo extends BaseCommand {
+			public static commandName = 'foo'
+
+			public async handle() {}
+		}
+
+		const app = new Application(__dirname, new Ioc(), {}, {})
+		const kernel = new Kernel(app)
+		kernel.register([Foo])
+
+		try {
+			await kernel.exec('foo', [])
+		} finally {
+			// @ts-expect-error
+			process.exit = function () {}
+		}
+	})
+
+	test('keep the command alive when having a long running process', async () => {
+		process.exit = () => {
+			throw new Error('Should never be reached')
+		}
+
+		class Foo extends BaseCommand {
+			public static commandName = 'foo'
+			public static stayAlive = true
+
+			public async handle() {}
+		}
+
+		const app = new Application(__dirname, new Ioc(), {}, {})
+		const kernel = new Kernel(app)
+		kernel.register([Foo])
+
+		try {
+			await kernel.exec('foo', [])
+		} finally {
+			// @ts-expect-error
+			process.exit = function () {}
+		}
 	})
 })


### PR DESCRIPTION
Hey there! 👋 

This PR remove the undesired behavior of not terminating the process when a command is ran and has long running process inside it (like opened database connections).

Now, if you want your command to hang, you will need to add the property `stayAlive` to it.

```ts
class Foo extends BaseCommand {
  public static commandName = 'foo'
  public static get settings() {
    return {
      stayAlive: true,
    }
  }

  public async handle() {
    // ...
  }
}
```

By default, the command will always terminate the process after it has been handled.
**Note, this is breaking change.**