### PR TITLE
fix: generate "pretty" ace-manifest.json

### DIFF
--- a/src/Manifest/Generator.ts
+++ b/src/Manifest/Generator.ts
@@ -97,6 +97,6 @@ export class ManifestGenerator {
       { commands: {}, aliases: {} }
     )
 
-    await outputJSON(join(this.basePath, 'ace-manifest.json'), manifest)
+    await outputJSON(join(this.basePath, 'ace-manifest.json'), manifest, { spaces: 2 })
   }
 }


### PR DESCRIPTION
Since the file must always be regenerated manually even during development,
it seems useful to commit it with the project.
A pretty-printed JSON is easier to read in code review than a one-line dump.

