### PR TITLE
Maintain set of processed files when generating manifest

### DIFF
--- a/src/Manifest/Generator.ts
+++ b/src/Manifest/Generator.ts
@@ -21,6 +21,12 @@ import { CommandConstructorContract, ManifestNode } from '../Contracts'
  * up the boot cycle of ace
  */
 export class ManifestGenerator {
+  /**
+   * Here we keep track of processed command files to prevent loops. Mainly when using
+   * listDirectoryFiles to export command paths from directory and not excluding current file.
+   */
+  private processedFiles: Set<string> = new Set()
+
   constructor(private basePath: string, private commands: string[]) {}
 
   /**
@@ -37,7 +43,16 @@ export class ManifestGenerator {
       )
     }
 
-    const commandOrSubCommandsPaths = esmRequire(resolveFrom(this.basePath, commandPath))
+    const resolvedPath = resolveFrom(this.basePath, commandPath)
+
+    if (this.processedFiles.has(resolvedPath)) {
+      return []
+    }
+
+    const commandOrSubCommandsPaths = esmRequire(resolvedPath)
+
+    this.processedFiles.add(resolvedPath)
+
     if (Array.isArray(commandOrSubCommandsPaths)) {
       return this.loadCommands(commandOrSubCommandsPaths)
     }

--- a/test/manifest-generator.spec.ts
+++ b/test/manifest-generator.spec.ts
@@ -201,7 +201,7 @@ test.group('Manifest Generator', (group) => {
       'Commands/index.ts',
       `
       import { listDirectoryFiles } from '../../../index'
-      export default listDirectoryFiles(__dirname, '${fs.basePath}')
+      export default listDirectoryFiles(__dirname, '${fs.basePath.replace(/\\/g, '\\\\')}')
     `
     )
 


### PR DESCRIPTION
## Proposed changes

Just a small improvement for generating manifest. Updated `ManifestGenerator` to maintain set of processed files so we avoid reprocessing the same files twice. This also prevents the infinite loop when for example we are using `listDirectoryFiles` and not excluding the current file. For example this code in `commands/index.ts` previously caused an infinite loop and now it works.

```typescript
// export default listDirectoryFiles(__dirname, Application.appRoot, ['./commands/index'])
// here we omit the last argument
export default listDirectoryFiles(__dirname, Application.appRoot)
``` 

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/ace/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments
