### PR TITLE
Clean processed files from the previous run when generating manifest

### DIFF
--- a/src/Manifest/Generator.ts
+++ b/src/Manifest/Generator.ts
@@ -88,6 +88,9 @@ export class ManifestGenerator {
    * Generates and writes the ace manifest file to the base path
    */
   public async generate() {
+    // clean files from the old run when reusing the same instance
+    this.processedFiles.clear()
+
     const commands = await this.loadCommands(this.commands)
 
     const manifest = commands.reduce<ManifestNode>(

--- a/test/manifest-generator.spec.ts
+++ b/test/manifest-generator.spec.ts
@@ -176,6 +176,71 @@ test.group('Manifest Generator', (group) => {
     })
   })
 
+  test('generate manifest from command subpaths reusing generator instance', async ({ assert }) => {
+    await fs.add(
+      'Commands/Make.ts',
+      `
+    import { args, flags } from '../../../index'
+    import { BaseCommand } from '../../../src/BaseCommand'
+
+    export default class Greet extends BaseCommand {
+      public static commandName = 'greet'
+      public static description = 'Greet a user'
+
+      @args.string()
+      public name: string
+
+      @flags.boolean()
+      public adult: boolean
+
+      public async run () {}
+    }`
+    )
+
+    await fs.add(
+      'Commands/index.ts',
+      `
+      export default [
+        './Commands/Make',
+      ]
+    `
+    )
+
+    const manifest = new ManifestGenerator(fs.basePath, ['./Commands/index.ts'])
+
+    await manifest.generate()
+    await manifest.generate()
+
+    const manifestJSON = await fs.fsExtra.readJSON(join(fs.basePath, 'ace-manifest.json'))
+    assert.deepEqual(manifestJSON, {
+      commands: {
+        greet: {
+          settings: {},
+          aliases: [],
+          commandPath: './Commands/Make',
+          commandName: 'greet',
+          description: 'Greet a user',
+          args: [
+            {
+              name: 'name',
+              type: 'string',
+              propertyName: 'name',
+              required: true,
+            },
+          ],
+          flags: [
+            {
+              name: 'adult',
+              propertyName: 'adult',
+              type: 'boolean',
+            },
+          ],
+        },
+      },
+      aliases: {},
+    })
+  })
+
   test('generate manifest from command subpaths using listDirectoryFiles', async ({ assert }) => {
     await fs.add(
       'Commands/Make.ts',


### PR DESCRIPTION
## Proposed changes

Fix for my previous PR #143. In case we are reusing the manifest generator we need to clear processed files, or the generated manifest will be empty.
EDIT: looks like we are using in assembler always the fresh instance so this actually does not fix anything. So we can close it or just merge as an improvement just in case.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/ace/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
