### PR TITLE
feat: add absoluteFilePath to CommandMetadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "pretest": "npm run lint",
-    "test": "cross-env NODE_DEBUG=adonisjs:ace c8 npm run vscode:test",
+    "test": "cross-env NODE_DEBUG=adonisjs:ace c8 npm run quick:test",
     "clean": "del-cli build",
     "build:schema": "ts-json-schema-generator --path='src/types.ts' --type='CommandMetaData' --tsconfig='tsconfig.json' --out='schemas/command_metadata_schema.json'",
     "copy:files": "copyfiles schemas/* stubs/*.stub build",
@@ -35,7 +35,7 @@
     "lint": "eslint . --ext=.ts",
     "format": "prettier --write .",
     "sync-labels": "github-label-sync --labels .github/labels.json adonisjs/ace",
-    "vscode:test": "node --loader=ts-node/esm bin/test.ts"
+    "quick:test": "node --loader=ts-node/esm bin/test.ts"
   },
   "keywords": [
     "adonisjs",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@swc/core": "^1.3.51",
     "@types/node": "^18.15.11",
     "@types/string-similarity": "^4.0.0",
+    "@types/yargs-parser": "^21.0.0",
     "c8": "^7.13.0",
     "copyfiles": "^2.4.1",
     "cross-env": "^7.0.3",

--- a/src/loaders/fs_loader.ts
+++ b/src/loaders/fs_loader.ts
@@ -8,7 +8,7 @@
  */
 
 import { fileURLToPath } from 'node:url'
-import { basename, extname, relative } from 'node:path'
+import { basename, extname, join, relative } from 'node:path'
 import { fsReadAll, importDefault, slash } from '@poppinss/utils'
 
 import { validateCommand } from '../helpers.js'
@@ -35,7 +35,7 @@ export class FsLoader<Command extends AbstractBaseCommand> implements LoadersCon
   /**
    * An array of loaded commands
    */
-  #commands: { command: Command; filePath: string }[] = []
+  #commands: { command: Command; filePath: string; absoluteFilePath: string }[] = []
 
   constructor(comandsDirectory: string, filter?: (filePath: string) => boolean) {
     this.#comandsDirectory = comandsDirectory
@@ -112,11 +112,16 @@ export class FsLoader<Command extends AbstractBaseCommand> implements LoadersCon
     Object.keys(commandsCollection).forEach((key) => {
       const command = commandsCollection[key]
       validateCommand<Command>(command, `"${key}" file`)
-      this.#commands.push({ command, filePath: key })
+
+      this.#commands.push({
+        command,
+        filePath: key,
+        absoluteFilePath: slash(join(this.#comandsDirectory, key)),
+      })
     })
 
-    return this.#commands.map(({ command, filePath }) => {
-      return Object.assign({}, command.serialize(), { filePath })
+    return this.#commands.map(({ command, filePath, absoluteFilePath }) => {
+      return Object.assign({}, command.serialize(), { filePath, absoluteFilePath })
     })
   }
 

--- a/tests/loaders/fs_loader.spec.ts
+++ b/tests/loaders/fs_loader.spec.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path'
 import { test } from '@japa/runner'
 import { fileURLToPath } from 'node:url'
 import { FsLoader } from '../../src/loaders/fs_loader.js'
+import { slash } from '@poppinss/utils'
 
 const BASE_URL = new URL('./tmp/', import.meta.url)
 const BASE_PATH = fileURLToPath(BASE_URL)
@@ -74,6 +75,7 @@ test.group('Loaders | fs', (group) => {
     assert.deepEqual(commands, [
       {
         filePath: 'make_controller_v_2.js',
+        absoluteFilePath: slash(join(fs.basePath, './commands/make_controller_v_2.js')),
         commandName: 'make:controller',
         description: '',
         namespace: 'make',
@@ -119,6 +121,7 @@ test.group('Loaders | fs', (group) => {
       {
         commandName: 'make:controller',
         filePath: 'make_controller.js',
+        absoluteFilePath: slash(join(fs.basePath, './commands/make_controller.js')),
         description: '',
         namespace: 'make',
         args: [],
@@ -165,6 +168,7 @@ test.group('Loaders | fs', (group) => {
       {
         commandName: 'make:controller',
         filePath: 'make_controller_v_3.js',
+        absoluteFilePath: slash(join(fs.basePath, './commands/make_controller_v_3.js')),
         description: '',
         namespace: 'make',
         args: [],
@@ -251,6 +255,7 @@ test.group('Loaders | fs', (group) => {
       {
         commandName: 'make:controller',
         filePath: 'make/controller.js',
+        absoluteFilePath: slash(join(fs.basePath, './commands/make/controller.js')),
         description: '',
         namespace: 'make',
         args: [],
@@ -323,6 +328,7 @@ test.group('Loaders | fs', (group) => {
     const commands = await loader.getMetaData()
     assert.deepEqual(commands, [
       {
+        absoluteFilePath: slash(join(fs.basePath, 'commands/make/controller.js')),
         commandName: 'make:controller',
         filePath: 'make/controller.js',
         description: '',


### PR DESCRIPTION
as discussed this PR add the `absoluteFilePath` property to `CommandMetadata` only for the Filesystem loader

also added @types/yargs-parser since it was missing from devDeps and yargs-parser is not typed