### PR TITLE
test: add failed test and edge case

### DIFF
--- a/src/Parser/index.ts
+++ b/src/Parser/index.ts
@@ -56,6 +56,10 @@ export class Parser {
     /**
      * Register alias (when exists)
      */
+    if (flag.type === 'string') {
+      options.string!.push(flag.name)
+    }
+
     if (flag.alias) {
       options.alias![flag.alias] = flag.name
     }
@@ -193,7 +197,7 @@ export class Parser {
      *
      * It is fine. Flags are optional anyways
      */
-    if (value === undefined) {
+    if (value === undefined || value === '') {
       return
     }
 

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -100,6 +100,20 @@ test.group('Parser | flags', () => {
     assert.deepEqual(output, { _: [], admin: 'true' })
   })
 
+  test('parse big "numbered" string as real string', ({ assert }) => {
+    const parser = new Parser({
+      str: {
+        type: 'string',
+        name: 'str',
+        propertyName: 'str',
+        handler: () => {},
+      },
+    })
+
+    const output = parser.parse(['--str=111111111111111111111111'])
+    assert.deepEqual(output, { _: [], str: '111111111111111111111111' })
+  })
+
   test('do not define string flag when it is not mentioned', ({ assert }) => {
     const parser = new Parser({
       admin: {


### PR DESCRIPTION
## Problems

We should allow user's to pass big string on ace commands without making them numbered.
For example => 111111111111111111111111 should still be "111111111111111111111111" after getopt output.
(Actually getopt transform this to a number).

A simple fix should be to add the flag on the string option of getopt. But, if we do that, we have some bug on the application. Because, getopt transform empty flag to empty string

```
getopt("--str=111111111111111111111111", { string: ["str", "test"] })
```
will return something like:

```json
{
  "str": "111111111111111111111111",
  "test": ""
} 
```

An issue about something like that already exist here : https://github.com/jorgebucaran/getopts/issues/53

I added a failed test, who explain the "problems" we found on ace
