### PR TITLE
fix: incorporate missing spaces in 'list command' help text

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -27,10 +27,10 @@ export class ListCommand extends BaseCommand {
   static description: string = 'View list of available commands'
   static help = [
     'The list command displays a list of all the commands:',
-    '  {{ binaryName }}list',
+    '  {{ binaryName }} list',
     '',
     'You can also display the commands for a specific namespace:',
-    '  {{ binaryName }}list <namespace...>',
+    '  {{ binaryName }} list <namespace...>',
   ]
 
   /**

--- a/tests/commands/list.spec.ts
+++ b/tests/commands/list.spec.ts
@@ -251,10 +251,10 @@ test.group('List command', () => {
         description: 'View list of available commands',
         help: [
           'The list command displays a list of all the commands:',
-          '  {{ binaryName }}list',
+          '  {{ binaryName }} list',
           '',
           'You can also display the commands for a specific namespace:',
-          '  {{ binaryName }}list <namespace...>',
+          '  {{ binaryName }} list <namespace...>',
         ],
         namespace: null,
         aliases: [],


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

In the current implementation, as illustrated in the example, the output is generated as follows:
``` 
 The list command displays a list of all the commands:
    node acelist
```

To rectify this, the implementation has been modified to produce the following output:
``` 
 The list command displays a list of all the commands:
    node ace list
```

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/ace/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
