### PR TITLE
fix: support command metadata validation on Node.js 24.20+

### DIFF
--- a/schemas/main.ts
+++ b/schemas/main.ts
@@ -8,6 +8,7 @@
  */
 
 export const schema = {
+  $id: 'adonisjs://ace/command-metadata',
   $ref: '#/definitions/CommandMetaData',
   $schema: 'http://json-schema.org/draft-07/schema#',
   definitions: {


### PR DESCRIPTION
## Description

Fixes #169.

Starting with Node.js 24.20.0, command metadata validation can fail with an `Invalid URL` error.

The command metadata schema uses local fragment references, but does not define a base URI. `jsonschema` therefore attempts to resolve these references against its anonymous base, which is rejected by newer Node.js URL parsing behavior.

This change defines a stable, non-HTTP schema identifier:

```text
adonisjs://ace/command-metadata
```

It is used only as an in-memory base URI when resolving references such as `#/definitions/CommandMetaData`. It is never fetched over the network.

## Compatibility

Verified with:

- Node.js 24.19.0: 10/10 targeted tests passing
- Node.js 24.20.0: 10/10 targeted tests passing
- Node.js 26.7.0: 10/10 targeted tests passing
- Node.js 26.7.0: 256/256 full test suite passing

## Changes

Adds a `$id` to the command metadata JSON schema:

```diff
 export const schema = {
+  $id: "adonisjs://ace/command-metadata",
   $ref: "#/definitions/CommandMetaData",
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added a unique identifier to the command metadata schema for improved schema recognition and tooling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->