### PR TITLE
fix: preserve original error when formatting fails

### DIFF
--- a/src/exception_handler.ts
+++ b/src/exception_handler.ts
@@ -137,6 +137,10 @@ export class ExceptionHandler {
       return
     }
 
-    return this.prettyPrintError(error)
+    try {
+      await this.prettyPrintError(error)
+    } catch {
+      kernel.ui.logger.fatal(error as any)
+    }
   }
 }

--- a/tests/exception_handler.spec.ts
+++ b/tests/exception_handler.spec.ts
@@ -103,6 +103,26 @@ test.group('Exception handler', () => {
     assert.equal(logs[0].message, 'Pretty printing: Something went wrong')
   })
 
+  test('fallback to the logger when pretty printing fails', async ({ assert }) => {
+    const kernel = Kernel.create()
+    kernel.ui.switchMode('raw')
+    let loggedError: unknown
+    kernel.ui.logger.fatal = (error) => {
+      loggedError = error
+    }
+
+    class CustomExceptionHandler extends ExceptionHandler {
+      protected async prettyPrintError() {
+        throw new Error('Unable to load error formatter')
+      }
+    }
+
+    const error = new Error('Something went wrong')
+    await new CustomExceptionHandler().render(error, kernel)
+
+    assert.strictEqual(loggedError, error)
+  })
+
   test('do not pretty print when not in debug mode', async ({ assert }) => {
     const kernel = Kernel.create()
     kernel.ui.switchMode('raw')


### PR DESCRIPTION
Hey! 👋🏻 

This PR adds a fallback that if `prettyPrintError` throws we fallback to using `kernel.ui.logger.fatal`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when debug error formatting fails.
  * Errors are now logged through the fatal logger instead of being lost or interrupting error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->